### PR TITLE
Problem: Code block layout broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Quickstart
 
     The response will look something like:
 
-    > ```json
+    ```json
     {
       "message": "Actor execution retrieved successfully.",
       "result": {
@@ -229,7 +229,7 @@ Quickstart
       "status": "success",
       "version": ":dev"
     }
-    > ```
+    ```
 
 6.  You can also retrieve the logs (as in docker logs) for any execution:
 


### PR DESCRIPTION
The quote characters (`> `) are only in front of the first and last lines of the code block. They need to be before each of the code lines, or none of them.

Solution: I just removed them. Most of the other long code blocks don't have the quote characters.

Currently it looks like this:

![screen shot 2018-04-27 at 7 37 44 pm](https://user-images.githubusercontent.com/742633/39391054-9f02a6ea-4a52-11e8-962c-29be2f965523.png)

After my fix it looks like this:

<img width="780" alt="screen shot 2018-04-27 at 7 39 41 pm" src="https://user-images.githubusercontent.com/742633/39391070-e1802c90-4a52-11e8-9ee7-33e86c3da227.png">

