### PR TITLE
Added hints, webhook image, and makefile changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,21 @@
 # Makefile for local development
 
+.PHONY: clean prune nuke
 
-# Retrieves present working directory (./abaco) and sets :dev tag
-export abaco_path = ${PWD}
-export TAG = :dev
+# Retrieves present working directory (./abaco) and sets abaco tag based on
+# current or default values
+ifdef abaco_path
+export abaco_path := $(abaco_path)
+else
+export abaco_path := $(PWD)
+endif
+ 
+ifdef TAG
+export TAG := $(TAG)
+else
+export TAG := :dev
+endif
+
 
 # Builds Docker images to run local-dev (abaco/core, abaco/prom, abaco/nginx, etc.)
 build:
@@ -20,19 +32,36 @@ build:
 	@docker pull abaco/prom$$TAG
 	@docker pull abaco/dashboard
 
+
+# Build local
+local-build:
+	@docker build ./ -t abaco/core:dev
+
+
 # Starts up local environment (docker containers) in daemon mode
 deploy: build
 	@docker-compose up -d
 
+
+local-deploy: local-build
+	@docker-compose up -d
+
+# Deploys, but not silently and will abort if a container exits.
+test-deploy:
+	@docker-compose up --abort-on-container-exit
+
+
 # Runs test suite against current repository
 test: deploy
 	@./build_and_test.sh
+
 
 # Builds a few sample Docker images
 samples:
 	@docker build -t abaco_test -f samples/abaco_test/Dockerfile samples/abaco_test
 	@docker build -t docker_ps -f samples/docker_ps/Dockerfile samples/docker_ps
 	@docker build -t word_count -f samples/word_count/Dockerfile samples/word_count
+
 
 # Creates every Docker image in samples folder
 all-samples:
@@ -42,14 +71,23 @@ all-samples:
 		fi \
 	done
 
-# Cleanly remove docker images necessary for local-dev
+
+# Test variables
+test-vars:
+	@echo $$TAG
+	@echo $$abaco_path
+
+
+# Ends all active Docker containers needed for abaco
 clean:
 	@docker-compose down
 
-# Removes/ends all active Docker containers
-force-clean:
-	@docker rm -f `docker ps -aq`
 
-# WARNING: Deletes all non-active Docker images
+# Does a clean and also deletes all images needed for abaco
 prune:
-	@docker system prune -a
+	@docker-compose down --rmi all
+
+
+# Delete all images forcefully (so it also deletes containers)
+nuke:
+	@docker rm -f `docker ps -aq`

--- a/actors/models.py
+++ b/actors/models.py
@@ -87,7 +87,7 @@ class Event(object):
 
     def __init__(self, dbid: str, event_type: str, data: dict):
         """
-        Create a new even object
+        Create a new event object
         """
         self.db_id = dbid
         self.tenant_id = dbid.split('_')[0]
@@ -322,6 +322,7 @@ class Actor(AbacoDAO):
         ('type', 'optional', 'type', str, 'Return type (none, bin, json) for this actor. Default is none.', 'none'),
         ('link', 'optional', 'link', str, "Actor identifier of actor to link this actor's events too. May be an actor id or an alias. Cycles not permitted.", ''),
         ('webhook', 'optional', 'webhook', str, "URL to publish this actor's events to.", ''),
+        ('hints', 'optional', 'hints', str, 'Hints for personal tagging or Abaco special hints', ''),
         ('description', 'optional', 'description', str,  'Description of this actor', ''),
         ('privileged', 'optional', 'privileged', inputs.boolean, 'Whether this actor runs in privileged mode.', False),
         ('max_workers', 'optional', 'max_workers', int, 'How many workers this actor is allowed at the same time.', None),

--- a/samples/webhook/Dockerfile
+++ b/samples/webhook/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.7-alpine
+
+RUN pip install requests
+ADD webhook.py /code/
+
+CMD ["python", "/code/webhook.py"]

--- a/samples/webhook/README.md
+++ b/samples/webhook/README.md
@@ -1,0 +1,40 @@
+# Webhook Sample
+### Image: abacosamples/webhook
+A webhook image that allows for users to link to this and hook into a specified url.  
+This image provides additional features that the generic webhook
+feature does not. This image allows for retry logic, timeout logic, headers for
+authentication, and a backoff factor.
+ 
+This image utilizes urllib3 to enable the retries feature. 
+ 
+This image utilizes environment variables to set variables. URL is a required
+variable, while the others are optional and include: HEADERS, RETRIES_VAR,
+TIMEOUT_VAR, and BACKOFF_FAC. Environment variables can be set for an actor
+by providing a 'default_environment' dictionary at actor initialization as shown below.
+ 
+## Example Usage
+##### Creating webhook actor
+```python
+import json
+import requests as r
+webhook = r.post("http://localhost:8000/actors", 
+                 headers={"x-jwt-assertion-DEV-DEVELOP": exampleJWT,
+                 		  "Content-Type": "application/json"},
+                 data=json.dumps({"image": "abacosamples/webhooks",
+                                  "default_environment":{"URL": exampleURL,
+                                                         "HEADERS":{"Authentication": "Bearer exampleOAUTH",
+                                                                    "Content-Type": exampleTYPE}}}))
+webhook_id = webhook.json()['result']['id']
+```
+ 
+##### Creating actor linked to webhook
+```python
+actor = r.post("http://localhost:8000/actors", 
+               headers={"x-jwt-assertion-DEV-DEVELOP": exampleJWT,
+                 		"Content-Type": "application/json"},
+               data={"image": exampleIMAGE,
+                     "link": webhook_id}))
+```
+Now whenever this linked actor is created or is ran, a message will be sent to the specified URL with information regarding actor events.
+
+If you're looking to this out this feature, [webhook.site](https://webhook.site) allows users to see all information regarding HTTP requests to a unique URL.

--- a/samples/webhook/webhook.py
+++ b/samples/webhook/webhook.py
@@ -1,0 +1,69 @@
+"""
+Webhook example that allows users to link to this image in Abaco and use it for
+webhooks. This image provides additional features that the generic webhook
+feature does not. This image allows for retry logic, timeout logic, headers for
+authentication, and a backoff factor.
+
+This image utilizes urllib3 to enable the retries feature. 
+
+This image utilizes environment variables to set variables. URL is a required
+variable, while the others are optional and include, HEADERS, RETRIES_VAR,
+TIMEOUT_VAR, and BACKOFF_FAC. Environment variables can be set for an actor
+by providing a 'default_environment' dictionary at actor initialization.
+"""
+import os
+import json
+import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
+# REQUIRED: Get the URL set in 'default_environment' during actor init
+URL=os.environ.get('URL')
+# OPTIONAL: Adds in JSON formatted headers to comply with url expectations
+HEADERS=os.environ.get('HEADERS').replace("'",'"').replace('/','')
+# OPTIONAL: urllib3 variables set at init with 'default_environment'
+RETRIES_VAR=int(os.getenv('RETRIES_VAR', 3))
+TIMEOUT_VAR=int(os.getenv('TIMEOUT_VAR', 5))
+BACKOFF_FAC=float(os.getenv('BACKOFF_FAC', 0.3))
+# DERIVED: Gets event message from the linked image
+EVENT_MSG=os.environ.get('MSG')
+
+
+# The actual posting logic using urllib3 for retries, timeouts, and more
+def requests_retry_session(
+    retries=RETRIES_VAR, 
+    backoff_factor=0.3,
+    status_forcelist=(500, 502, 504),
+    session=None,):
+    session = session or requests.Session()
+    retry = Retry(
+        total=retries,
+        read=retries,
+        connect=retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist)
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+    return session
+
+
+# Creating a requests session so that we can have headers, auth, etc.
+s = requests.Session()
+# urllib3 basic auth possible, but headers is just more verbose
+#s.auth = ('user', 'pass')
+# If headers are applied they are then added to session headers
+if HEADERS:
+    try:
+        HEADERS = json.loads(HEADERS)
+        s.headers.update(HEADERS)
+    except Exception as e:
+        raise e
+# Trys to make an actual post
+try:
+    res = requests_retry_session(session=s).post(
+        URL,
+        data=EVENT_MSG,
+        timeout=TIMEOUT_VAR)
+except Exception as e:
+    print('Error:', e)


### PR DESCRIPTION
Added hints in models.py, allows for a tag-like descriptor for actors.

Added webhook image, added image that when linked to allows for users to hook into URLs after abaco actor events.

Updated makefile to include local-build and local-deploy, these build an image based on your current Abaco directory allowing quicker testing of things. Also added changed prune to not delete all images and only deal with docker-compose. Also changed the env logic allowing for inputted variables rather than being set only to defaults.